### PR TITLE
bugfix(build): Fixes the case where the addon has been included more than once

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = {
     this._super.init.apply(this, arguments);
 
     // Create a root level version checker for checking the Ember version later on
-    this.emberChecker = new VersionChecker(project).forEmber();
+    this.emberChecker = new VersionChecker({ project, root: project.root }).forEmber();
 
     // Create a parent checker for checking the parent app/addons dependencies (for things like polyfills)
     const babelChecker = new VersionChecker(parent).for('ember-cli-babel', 'npm');

--- a/index.js
+++ b/index.js
@@ -34,52 +34,68 @@ function hasPlugin(plugins, name) {
 module.exports = {
   name: 'ember-decorators',
 
-  _getParentOptions: function() {
-    let options;
+  init(parent, project) {
+    this._super.init.apply(this, arguments);
 
-    // The parent can either be an Addon or a Project. If it's an addon,
-    // we want to use the app instead. This public method probably wasn't meant
-    // for this, but it's named well enough that we can use it for this purpose.
-    if (this.parent && !this.parent.isEmberCLIProject) {
-      options = this.parent.options = this.parent.options || {};
-    } else {
-      options = this.app.options = this.app.options || {};
+    // Create a root level version checker for checking the Ember version later on
+    this.emberChecker = new VersionChecker(project).forEmber();
+
+    // Create a parent checker for checking the parent app/addons dependencies (for things like polyfills)
+    const babelChecker = new VersionChecker(parent).for('ember-cli-babel', 'npm');
+
+    if (!babelChecker.satisfies('^6.0.0-beta.1')) {
+      project.ui.writeWarnLine(
+        'ember-legacy-class-transform: You are using an unsupported ember-cli-babel version, ' +
+        'legacy class transform will not be included automatically'
+      );
+
+      this._registeredWithBabel = true;
+    } else if (this.emberChecker.isAbove('2.13.0') && parent.isEmberCLIProject) {
+      // The transform is being used in an application, and no longer needed
+      project.ui.writeWarnLine(
+        'ember-legacy-class-transform: this transform is not needed for Ember >= 2.13.0'
+      );
+
+      this._registeredWithBabel = true;
     }
 
-    return options;
+    // Parent can either be an Addon or Project. If it is a Project, then ember-decorators is
+    // being included in a root level project and needs to register itself on the EmberApp or
+    // EmberAddon's options instead
+    if (!parent.isEmberCLIProject) {
+      this.registerTransformWithParent(parent);
+    }
   },
 
   included(app) {
     this._super.included.apply(this, arguments);
 
-    let parentOptions = this._getParentOptions();
+    // This hook only gets called from top level applications. If it is called and the addon
+    // has not already registered itself, it should register itself with the application
+    this.registerTransformWithParent(app);
+  },
 
-    let disableTransforms = parentOptions.emberDecorators && parentOptions.emberDecorators.disableTransforms;
+  /**
+   * Registers the legacy class transform with the parent addon or application.
+   *
+   * @param {Addon|EmberAddon|EmberApp} parent
+   */
+  registerTransformWithParent(parent) {
+    if (this._registeredWithBabel) return;
 
-    if (!this._registeredWithBabel && !disableTransforms) {
-      let emberChecker = new VersionChecker(app).forEmber();
-      let babelChecker = new VersionChecker(this.parent).for('ember-cli-babel', 'npm');
+    const parentOptions = parent.options = parent.options || {};
+    const EmberLegacyClassConstructor = requireTransform('babel-plugin-ember-legacy-class-constructor');
 
-      if (babelChecker.satisfies('^6.0.0-beta.1')) {
-        let EmberLegacyClassConstructor = requireTransform('babel-plugin-ember-legacy-class-constructor');
+    // Create babel options if they do not exist
+    parentOptions.babel = parentOptions.babel || {};
 
-        // Create babel options if they do not exist
-        parentOptions.babel = parentOptions.babel || {};
+    // Create and pull off babel plugins
+    const plugins = parentOptions.babel.plugins = parentOptions.babel.plugins || [];
 
-        // Create and pull off babel plugins
-        let plugins = parentOptions.babel.plugins = parentOptions.babel.plugins || [];
-
-        if (!emberChecker.isAbove('2.13.0') && !hasPlugin('ember-legacy-class-constructor')) {
-          plugins.push(EmberLegacyClassConstructor);
-        }
-      } else {
-        app.project.ui.writeWarnLine(
-          'ember-legacy-class-transform: You are using an unsupported ember-cli-babel version,' +
-          'legacy class constructor transform will not be included automatically'
-        );
-      }
-
-      this._registeredWithBabel = true;
+    if (!hasPlugin(plugins, 'ember-legacy-class-constructor')) {
+      plugins.push(EmberLegacyClassConstructor);
     }
+
+    this._registeredWithBabel = true;
   }
 };


### PR DESCRIPTION
The included hook only runs once per instance of the addon in the dependency graph. The babel transforms we are adding, however, are meant to be added to each addon that includes this addon as a dependency, as well as the root app. Because each addon has it's own version of ember-cli-babel, we have to make sure it happens for each of them.

To do this, we use the init hook instead of the included hook, since it runs each time the addon is created. Unfortunately, the init hook does not have any way to access the root app - that is only provided in the included hook. So, we still need to use included for the case where this addon is being used in an actual app.