### PR TITLE
refactor(shim): Convert to a shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
-[![Build Status](https://travis-ci.org/pzuraq/ember-legacy-class-transform.svg?branch=master)](https://travis-ci.org/pzuraq/ember-legacy-class-transform)
+[![Build Status](https://travis-ci.org/pzuraq/ember-legacy-class-shim.svg?branch=master)](https://travis-ci.org/pzuraq/ember-legacy-class-shim)
 
-# Deprecation Notice
+# ember-legacy-class-shim
 
-This transform has been deprecated in favor of the [ember-legacy-class-shim](https://github.com/pzuraq/ember-legacy-class-shim),
-which is overall a better solution to legacy class support in Ember.
-
-# ember-legacy-class-transform
-
-This addon adds a transform for using ES Classes with legacy versions of Ember (< 2.13.0).
-It transforms the class's `constructor` function into `init`, which allows both the
-`constructor` and class fields to work.
+This addon adds a shim which reopens `EmberObject` and redefines `.extend`. This allows
+older versions of Ember to use ES Classes with some restrictions.
 
 ## Why is this needed?
 
@@ -22,72 +16,18 @@ internally in Ember, _never_ calls `super`.
 This means that when we define a class using `class` it's constructor never gets run.
 A side-effect of this is that class fields, which are assigned _in_ the constructor, do
 not get assigned. This substantially reduces the usefulness of class syntax and decorators
-since they rely substantially on class fields working as expected.
+since they rely on class fields working as expected.
 
-## So what does this do?
+## What does it fix?
 
-When combined with the class fields transform, this takes classes defined like so:
-
-```js
-class Foo {
-  bar = 'baz';
-
-  constructor() {
-    // do something
-  }
-}
-```
-
-And transforms them into this:
-
-```js
-class Foo {
-  constructor() {
-    if (!this.__didInit) {
-      this.init();
-    }
-  }
-
-  init() {
-    // do something
-    this.bar = 'baz';
-    this.__didInit = true;
-  }
-}
-```
-
-### Wait, why does the constructor still exist and call init if it doesn't work?
-
-It actually _does_ work when you make objects/classes outside of the standard Ember
-container lifecycle, so just doing `Foo.create()` for instance. The logic in place
-ensures that `init` only gets called once in all cases.
-
-### Ok, any other caveats?
-
-`init` is very similar to `constructor`, it gets called in the same context at
-_almost_ the same time. The key difference is that when using classes normally,
-the subclass's constructor gets called first` meaning it gets to do any setup it
-wants before calling `super`. `init`, on the other hand, only gets called after
-most of the setup has been done (if extending from `Ember.Object`).
-
-Ultimately, the code flow _before_ calling `super` in `constructor` will differ
-between legacy versions and modern versions of Ember. To avoid this, simply call
-`super` as the very first thing in any classes which extend `Ember.Object`.
-
-```js
-class Foo extends Ember.Object {
-  constructor(...args) {
-    super(...args);
-
-    // do some things
-  }
-}
-```
+This fixes the double extend problem only. Actually fixing `.extend` requires changes to
+CoreObject directly and won't be fixed until later versions of Ember. Once you start using
+native class syntax, you can't go back.
 
 ## Installation
 
 * `git clone <repository-url>` this repository
-* `cd ember-legacy-class-transform`
+* `cd ember-legacy-class-shim`
 * `npm install`
 
 ## Running

--- a/index.js
+++ b/index.js
@@ -1,110 +1,40 @@
 /* eslint-env node */
 'use strict';
 
-const path = require('path');
 const VersionChecker = require('ember-cli-version-checker');
 
-function requireTransform(transformName) {
-  let plugin = require(transformName);
-
-  plugin = plugin.__esModule ? plugin.default : plugin;
-
-  // adding `baseDir` ensures that broccoli-babel-transpiler does not
-  // issue a warning and opt out of caching
-  let pluginPath = require.resolve(`${transformName}/package`);
-  let pluginBaseDir = path.dirname(pluginPath);
-  plugin.baseDir = () => pluginBaseDir;
-  plugin._name = transformName;
-
-  return plugin;
-}
-
-function hasPlugin(plugins, name) {
-  for (let maybePlugin of plugins) {
-    let plugin = Array.isArray(maybePlugin) ? maybePlugin[0] : maybePlugin;
-    let pluginName = typeof plugin === 'string' ? plugin : plugin.name || plugin._name;
-
-    if (pluginName === name) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 module.exports = {
-  name: 'ember-decorators',
+  name: 'ember-legacy-class-shim',
 
   included(parent) {
     this._super.included.apply(this, arguments);
+    this._ensureFindHost();
 
-    const host = this._findHost();
-
-    host.project.ui.writeWarnLine(
-      'ember-legacy-class-transform: This transform has been deprecated, please switch to ember-legacy-class-shim'
-    );
+    let host = this._findHost()
 
     // Create a root level version checker for checking the Ember version later on
     const emberChecker = new VersionChecker(host).forEmber();
 
-    // Create a parent checker for checking the parent app/addons dependencies (for things like polyfills)
-    const babelChecker = new VersionChecker(parent).for('ember-cli-babel', 'npm');
-
-    if (!babelChecker.satisfies('^6.0.0-beta.1')) {
+    if (!emberChecker.isAbove('2.13.0')) {
+      host.import('vendor/ember-legacy-class-shim.js');
+    } else if (parent === host) {
+      // The shim is being used in an application, and no longer needed
       host.project.ui.writeWarnLine(
-        'ember-legacy-class-transform: You are using an unsupported ember-cli-babel version, ' +
-        'legacy class transform will not be included automatically'
+        'ember-legacy-class-shim: This shim is not needed for Ember >= 2.13.0'
       );
-
-      this._registeredWithParent = true;
-    } else if (emberChecker.isAbove('2.13.0')) {
-      if (parent === host) {
-        // The transform is being used in an application, and no longer needed
-        host.project.ui.writeWarnLine(
-          'ember-legacy-class-transform: this transform is not needed for Ember >= 2.13.0'
-        );
-      }
-
-
-      this._registeredWithParent = true;
     }
-
-    this.registerTransformWithParent(parent);
   },
 
-  /**
-   * Registers the legacy class transform with the parent addon or application.
-   *
-   * @param {Addon|EmberAddon|EmberApp} parent
-   */
-  registerTransformWithParent(parent) {
-    if (this._registeredWithParent) return;
-
-    const parentOptions = parent.options = parent.options || {};
-
-    // Create babel options if they do not exist
-    parentOptions.babel = parentOptions.babel || {};
-
-    // Create and pull off babel plugins
-    const plugins = parentOptions.babel.plugins = parentOptions.babel.plugins || [];
-
-    if (!hasPlugin(plugins, 'babel-plugin-ember-legacy-class-constructor')) {
-      const EmberLegacyClassConstructor = requireTransform('babel-plugin-ember-legacy-class-constructor');
-
-      plugins.push(EmberLegacyClassConstructor);
+  _ensureFindHost() {
+    if (!this._findHost) {
+      this._findHost = function findHostShim() {
+        let current = this;
+        let app;
+        do {
+          app = current.app || app;
+        } while (current.parent.parent && (current = current.parent));
+        return app;
+      };
     }
-
-    this._registeredWithParent = true;
-  },
-
-  _findHost() {
-    let current = this;
-    let app;
-
-    do {
-      app = current.app || app;
-    } while (current.parent.parent && (current = current.parent));
-
-    return app;
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ember-legacy-class-transform",
-  "version": "0.1.5",
-  "description": "The default blueprint for ember-cli addons.",
+  "name": "ember-legacy-class-shim",
+  "version": "1.0.0",
+  "description": "Backwards compatibility for ES classes in Ember",
   "keywords": [
     "ember-addon"
   ],
@@ -11,15 +11,13 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "https://github.com/pzuraq/ember-legacy-class-transform",
+  "repository": "https://github.com/pzuraq/ember-legacy-class-shim",
   "scripts": {
     "build": "ember build",
     "start": "ember server",
     "test": "ember try:each"
   },
   "dependencies": {
-    "babel-plugin-ember-legacy-class-constructor": "^0.1.4",
-    "ember-cli-babel": "^6.3.0",
     "ember-cli-version-checker": "^2.0.0"
   },
   "devDependencies": {
@@ -27,6 +25,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.15.1",
+    "ember-cli-babel": "^6.3.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.0.0",
     "ember-cli-htmlbars": "^2.0.1",
@@ -49,9 +48,6 @@
     "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
-    "after": [
-      "ember-decorators"
-    ]
+    "configPath": "tests/dummy/config"
   }
 }

--- a/testem.js
+++ b/testem.js
@@ -15,7 +15,7 @@ module.exports = {
       '--remote-debugging-port=9222',
       '--window-size=1440,900',
       // Workaround for https://github.com/travis-ci/travis-ci/issues/8836
-      '--no-sandbox',
+      '--no-sandbox'
     ]
   }
 };

--- a/tests/unit/basic-test.js
+++ b/tests/unit/basic-test.js
@@ -2,21 +2,21 @@ import EmberObject from '@ember/object';
 
 import { module, test } from 'qunit';
 
-module('Trasform Test');
+module('Basic Test');
 
 test('Class constructor only gets called once with Ember Object', function(assert) {
   assert.expect(3);
 
   class Foo extends EmberObject {
     constructor() {
-      super();
+      super(...arguments);
       assert.ok(true);
     }
   }
 
   class Bar extends Foo {
     constructor() {
-      super();
+      super(...arguments);
       assert.ok(true);
     }
   }
@@ -36,7 +36,7 @@ test('Class constructor only gets called once with normal classes', function(ass
 
   class Bar extends Foo {
     constructor() {
-      super();
+      super(...arguments);
       assert.ok(true);
     }
   }
@@ -101,7 +101,7 @@ test('Class fields work with Ember Object (with constructor)', function(assert) 
     prop = 1;
 
     constructor() {
-      super();
+      super(...arguments);
       assert.ok(true);
     }
   }
@@ -110,7 +110,7 @@ test('Class fields work with Ember Object (with constructor)', function(assert) 
     anotherProp = 2;
 
     constructor() {
-      super();
+      super(...arguments);
       assert.ok(true);
     }
   }
@@ -130,4 +130,50 @@ test('Class fields work with Ember Object (with constructor)', function(assert) 
 
   assert.equal(bar.get('prop'), 1);
   assert.equal(bar.get('anotherProp'), 2);
+});
+
+
+test('Can extend from .extends', function(assert) {
+  assert.expect(3);
+
+  const Foo = EmberObject.extend({
+    init() {
+      this._super(...arguments);
+      assert.ok(true);
+    }
+  });
+
+  class Bar extends Foo {
+    constructor() {
+      super(...arguments);
+      assert.ok(true);
+    }
+  }
+
+  Foo.create();
+  Bar.create();
+});
+
+test('Class constructor call order is correct', function(assert) {
+  assert.expect(1);
+
+  let calls = [];
+
+  class Foo extends EmberObject {
+    constructor() {
+      calls.push('before-constructor');
+      super();
+      calls.push('after-constructor');
+    }
+
+    init() {
+      calls.push('before-init');
+      super.init(...arguments);
+      calls.push('after-init');
+    }
+  }
+
+  Foo.create();
+
+  assert.deepEqual(calls, ['before-constructor', 'before-init', 'after-init', 'after-constructor']);
 });

--- a/tests/unit/component-test.js
+++ b/tests/unit/component-test.js
@@ -1,6 +1,9 @@
 import Component from '@ember/component';
+import Service from '@ember/service';
 import RSVP from 'rsvp';
 import { action } from 'ember-decorators/object';
+import { service } from 'ember-decorators/service';
+import { addObserver } from '@ember/object/observers';
 
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent } from 'ember-qunit';
@@ -14,14 +17,14 @@ test('Constructor only gets called once with components', function(assert) {
 
   class FooComponent extends Component {
     constructor() {
-      super();
+      super(...arguments);
       assert.ok(true)
     }
   }
 
   class BarComponent extends FooComponent {
     constructor() {
-      super();
+      super(...arguments);
       assert.ok(true)
     }
   }
@@ -35,7 +38,74 @@ test('Constructor only gets called once with components', function(assert) {
   `);
 });
 
-test('Constructor only gets called once with components', function(assert) {
+test('Can extend from .extend', function(assert) {
+  assert.expect(3);
+
+  const FooComponent = Component.extend({
+    init() {
+      this._super(...arguments);
+      assert.ok(true)
+    }
+  });
+
+  class BarComponent extends FooComponent {
+    constructor() {
+      super(...arguments);
+      assert.ok(true)
+    }
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('component:bar-component', BarComponent);
+
+  this.render(hbs`
+    {{foo-component}}
+    {{bar-component}}
+  `);
+});
+
+test('Bindings still work correctly', function(assert) {
+  assert.expect(1);
+
+  let calls = [];
+
+  class FooComponent extends Component {
+    // This emulates @ember-decorators/argument, which will be the most feasible
+    // way to set values that are bound until changes in CoreObject
+    get foo() {
+      return this._foo;
+    }
+
+    set foo(value) {
+      if (value !== undefined) {
+        this._foo = value
+      }
+    }
+
+    didInsertElement() {
+      addObserver(this, 'foo', () => {
+        calls.push(this.get('foo'));
+      });
+    }
+  }
+
+  this.register('component:foo-component', FooComponent);
+
+  this.render(hbs`{{foo-component foo=bar}}`);
+
+  this.set('bar', false);
+  this.set('bar', true);
+  this.set('bar', false);
+  this.set('bar', false);
+  this.set('bar', true);
+  this.set('bar', 123);
+  this.set('bar', 123);
+
+  assert.deepEqual(calls, [false, true, false, true, 123], 'binding updated correctly');
+});
+
+
+test('Class properties are assigned properly and overriden properly', function(assert) {
   assert.expect(4);
 
   class FooComponent extends Component {
@@ -60,6 +130,82 @@ test('Constructor only gets called once with components', function(assert) {
 
   this.register('component:foo-component', FooComponent);
   this.register('component:bar-component', BarComponent);
+
+  this.register('template:components/foo-component', hbs`<button {{action 'foo'}}>Click Me!</button>`);
+  this.register('template:components/bar-component', hbs`<button {{action 'bar'}}>Click Me!</button>`);
+
+  this.render(hbs`
+    {{foo-component prop=3 anotherProp=4}}
+    {{bar-component prop=5 anotherProp=6}}
+  `);
+
+  return RSVP.all(findAll('button').map(click));
+});
+
+test('Declarative injections still work', function(assert) {
+  assert.expect(2);
+
+  const TestService = Service.extend({
+    prop: 123
+  });
+
+  class FooComponent extends Component {
+    @service test;
+
+    @action
+    foo() {
+      assert.equal(this.get('test.prop'), 123);
+    }
+  }
+
+  class BarComponent extends FooComponent {
+    @action
+    bar() {
+      assert.equal(this.get('test.prop'), 123);
+    }
+  }
+
+  this.register('service:test', TestService);
+  this.register('component:foo-component', FooComponent);
+  this.register('component:bar-component', BarComponent);
+
+  this.register('template:components/foo-component', hbs`<button {{action 'foo'}}>Click Me!</button>`);
+  this.register('template:components/bar-component', hbs`<button {{action 'bar'}}>Click Me!</button>`);
+
+  this.render(hbs`
+    {{foo-component prop=3 anotherProp=4}}
+    {{bar-component prop=5 anotherProp=6}}
+  `);
+
+  return RSVP.all(findAll('button').map(click));
+});
+
+test('Imperative injections still work', function(assert) {
+  assert.expect(2);
+
+  const TestService = Service.extend({
+    prop: 123
+  });
+
+  class FooComponent extends Component {
+    @action
+    foo() {
+      assert.equal(this.get('test.prop'), 123);
+    }
+  }
+
+  class BarComponent extends FooComponent {
+    @action
+    bar() {
+      assert.equal(this.get('test.prop'), 123);
+    }
+  }
+
+  this.register('service:test', TestService);
+  this.register('component:foo-component', FooComponent);
+  this.register('component:bar-component', BarComponent);
+
+  this.registry.injection('component', 'test', 'service:test');
 
   this.register('template:components/foo-component', hbs`<button {{action 'foo'}}>Click Me!</button>`);
   this.register('template:components/bar-component', hbs`<button {{action 'bar'}}>Click Me!</button>`);

--- a/vendor/ember-legacy-class-shim.js
+++ b/vendor/ember-legacy-class-shim.js
@@ -1,0 +1,36 @@
+/* globals Ember, DS */
+(function() {
+  var ExtendOverrideMixin = Ember.Mixin.create({
+    extend: function() {
+      if (Object.getPrototypeOf(this) === Function.prototype) {
+        // The class we're extending is a base class, does not have anything
+        // else in the prototype chain, so continue as normal
+        return this._super.apply(this, arguments);
+      }
+
+      // Create a simple wrapper class to defer to the rest of the prototype chain
+      // for native classes and classes that extend from native classes
+      var Class = class extends this {};
+
+      for (var i = 0; i < arguments.length; i++) {
+        Object.assign(Class.prototype, arguments[i]);
+      }
+
+      return Class;
+    }
+  });
+
+  // reopen Ember.Object directly to pass in the extends so it and all subclasses get it
+  Ember.Object.reopenClass(ExtendOverrideMixin);
+
+  // class methods like 'extend' are finalized on the class when the class is first
+  // defined (via extend) so we need to manually apply the "mixin". This is not a
+  // problem with classes that extend further down the chain.
+  ExtendOverrideMixin.apply(Ember.Component);
+  ExtendOverrideMixin.apply(Ember.Service);
+  ExtendOverrideMixin.apply(Ember.Controller);
+
+  if (window.DS !== undefined && DS.Model !== undefined) {
+    ExtendOverrideMixin.apply(DS.Model);
+  }
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,10 +623,6 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-ember-legacy-class-constructor@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-legacy-class-constructor/-/babel-plugin-ember-legacy-class-constructor-0.1.4.tgz#dfe715b9bdb66f6c7e9eccc620137c03b3fa89e0"
-
 babel-plugin-ember-modules-api-polyfill@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.0.1.tgz#baaf26dcebe2ed1de120021bc42be29f520497b3"


### PR DESCRIPTION
After exploring CoreObject more as we're trying to fix ES Classes in
general, we've found a way to monkeypatch Ember instead of using a babel
transform. This method is likely to be much more efficient and inline
with future behavior of classes, so we're opting to switch to this
strategy.